### PR TITLE
Update readme to get rid of confusing brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ If you want step-by-step instructions, check out the [Stormpath ASP.NET Core qui
   Open your key file and grab the **API Key ID** and **API Key Secret**, then run these commands in PowerShell (or the Windows Command Prompt) to save them as environment variables:
 
   ```
-  setx STORMPATH_CLIENT_APIKEY_ID "[value from properties file]"
-  setx STORMPATH_CLIENT_APIKEY_SECRET "[value from properties file]"
+  setx STORMPATH_CLIENT_APIKEY_ID "value from properties file"
+  setx STORMPATH_CLIENT_APIKEY_SECRET "value from properties file"
   ```
   
 4. **Store your Stormpath Application href in an environment variable**
@@ -32,7 +32,7 @@ If you want step-by-step instructions, check out the [Stormpath ASP.NET Core qui
   Save this as an environment variable:
 
   ```
-  setx STORMPATH_APPLICATION_HREF "[your Application href]"
+  setx STORMPATH_APPLICATION_HREF "your Application href"
   ```
 
 5. **Clone this repository**


### PR DESCRIPTION
I was using the brackets [] and was getting all sorts of strange errors. I'm used to seeing <value> like this and know to leave out the <>, but never [value]. I'm willing to admit that maybe I'm the only one who has been thrown by this.